### PR TITLE
Rename missing values from NODATA to —

### DIFF
--- a/static/app/models/value.ts
+++ b/static/app/models/value.ts
@@ -4,7 +4,7 @@ export class Value{
 	
 	constructor(public num:number = undefined){
 		this.units = Value.ToUnits(num);
-		this.str = this.units || 'NODATA';
+		this.str = this.units || '—';
 	}
 		
 	static ToUnits(v: number): string {


### PR DESCRIPTION
Before this change, there were two usages for NODATA keyword:

1. When a trigger or metric is in NODATA _state_.
2. When a metric has no _value_.

It caused confusion in Moira users, especially when trigger was configured to set OK state after TTL period. Metrics would have NODATA _value_, but OK _state_.

This change removes NODATA keyword from any _value_ usages.